### PR TITLE
Replace Flink Scala libraries with Java equivalents

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Issues:
 * as this project relies on macro to derive TypeSerializer instances, if you're using IntelliJ 2020.*, it may
 highlight your code with red, hinting that it cannot find corresponding implicits. And this is fine, the code
 compiles OK. 2021 is fine with serializers derived with this library.
-* this library is built for Flink 1.14, but marks the `flink-*` dependencies as `provided`, so it should also work with earlier
-versions
+* this library is built for Flink 1.15, which supports arbitrary Scala versions.
 * Supports only Scala 2.12: underlying Magnolia library has no support for 2.11
   
 ## Usage
@@ -34,14 +33,16 @@ To use this library, swap `import org.apache.flink.api.scala._` with `import io.
 So to derive a TypeInformation for a sealed trait, you can do:
 ```scala
 import io.findify.flinkadt.api._
+import org.apache.flink.api.common.typeinfo.TypeInformation
 
-sealed trait Event
-case class Click(id: String) extends Event
-case class Purchase(price: Double) extends Event
+sealed trait Event extends Product with Serializable
 
-// env is a StreamingExecutionEnvironment
-val result = env.fromCollection(List[Event](Click("1"), Purchase(1.0))).executeAndCollect(10)
+object Event {
+  final case class Click(id: String) extends Event
+  final case class Purchase(price: Double) extends Event
 
+  implicit val eventTypeInfo: TypeInformation[Event] = deriveTypeInformation
+}
 ```
 
 Be careful with a wildcard import of `import org.apache.flink.api.scala._`: it has a `createTypeInformation` implicit

--- a/build.sbt
+++ b/build.sbt
@@ -12,15 +12,18 @@ publishMavenStyle := true
 
 publishTo := sonatypePublishToBundle.value
 
-lazy val flinkVersion = "1.14.0"
+// Use snapshot of Flink 1.15 for now.
+// Otherwise impossible to import `flink-test-utils` without transitive Scala dependency.
+resolvers += "Apache Snapshots" at "https://repository.apache.org/content/repositories/snapshots/"
+lazy val flinkVersion = "1.15-20220128.014046-92"
 
 libraryDependencies ++= Seq(
-  "com.softwaremill.magnolia1_2" % "magnolia_2.12"         % "1.0.0-M7",
-  "org.apache.flink"            %% "flink-scala"           % flinkVersion % "provided",
-  "org.apache.flink"            %% "flink-streaming-scala" % flinkVersion % "provided",
-  "org.apache.flink"            %% "flink-test-utils"      % flinkVersion % "test",
-  "org.scalatest"               %% "scalatest"             % "3.2.10"     % "test",
-  "org.typelevel"               %% "cats-core"             % "2.7.0"      % "test"
+  "com.softwaremill.magnolia1_2" %% "magnolia" % "1.0.0-M8",
+  "org.apache.flink" % "flink-java" % flinkVersion % "provided",
+  "org.apache.flink" % "flink-test-utils" % flinkVersion % "test",
+  "org.scalatest" %% "scalatest" % "3.2.10" % "test",
+  "org.typelevel" %% "cats-core" % "2.7.0" % "test",
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value
 )
 
 scmInfo := Some(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.6.1

--- a/src/main/java/io/findify/flinkadt/api/serializer/ScalaCaseClassSerializerSnapshot.java
+++ b/src/main/java/io/findify/flinkadt/api/serializer/ScalaCaseClassSerializerSnapshot.java
@@ -1,0 +1,92 @@
+package io.findify.flinkadt.api.serializer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** {@link TypeSerializerSnapshot} for {@link ScalaCaseClassSerializer}. */
+@Internal
+public final class ScalaCaseClassSerializerSnapshot<T extends scala.Product>
+        extends CompositeTypeSerializerSnapshot<T, ScalaCaseClassSerializer<T>> {
+
+    private static final int VERSION = 2;
+
+    private Class<T> type;
+
+    /** Used via reflection. */
+    @SuppressWarnings("unused")
+    public ScalaCaseClassSerializerSnapshot() {
+        super(ScalaCaseClassSerializer.class);
+    }
+
+    /**
+     * Used for delegating schema compatibility checks from serializers that were previously using
+     * {@code TupleSerializerConfigSnapshot}. Type is the {@code outerSnapshot} information, that is
+     * required to perform {@link #internalResolveSchemaCompatibility(TypeSerializer,
+     * TypeSerializerSnapshot[])}.
+     *
+     * <p>This is used in {@link
+     * ScalaCaseClassSerializer#resolveSchemaCompatibilityViaRedirectingToNewSnapshotClass(TypeSerializerConfigSnapshot)}.
+     */
+    @Internal
+    ScalaCaseClassSerializerSnapshot(Class<T> type) {
+        super(ScalaCaseClassSerializer.class);
+        this.type = checkNotNull(type, "type can not be NULL");
+    }
+
+    /** Used for the snapshot path. */
+    public ScalaCaseClassSerializerSnapshot(ScalaCaseClassSerializer<T> serializerInstance) {
+        super(serializerInstance);
+        this.type = checkNotNull(serializerInstance.getTupleClass(), "tuple class can not be NULL");
+    }
+
+    @Override
+    protected int getCurrentOuterSnapshotVersion() {
+        return VERSION;
+    }
+
+    @Override
+    protected TypeSerializer<?>[] getNestedSerializers(
+            ScalaCaseClassSerializer<T> outerSerializer) {
+        return outerSerializer.getFieldSerializers();
+    }
+
+    @Override
+    protected ScalaCaseClassSerializer<T> createOuterSerializerWithNestedSerializers(
+            TypeSerializer<?>[] nestedSerializers) {
+        checkState(type != null, "type can not be NULL");
+        return new ScalaCaseClassSerializer<>(type, nestedSerializers);
+    }
+
+    @Override
+    protected void writeOuterSnapshot(DataOutputView out) throws IOException {
+        checkState(type != null, "type can not be NULL");
+        out.writeUTF(type.getName());
+    }
+
+    @Override
+    protected void readOuterSnapshot(
+            int readOuterSnapshotVersion, DataInputView in, ClassLoader userCodeClassLoader)
+            throws IOException {
+        this.type = InstantiationUtil.resolveClassByName(in, userCodeClassLoader);
+    }
+
+    @Override
+    protected CompositeTypeSerializerSnapshot.OuterSchemaCompatibility
+    resolveOuterSchemaCompatibility(ScalaCaseClassSerializer<T> newSerializer) {
+        return (Objects.equals(type, newSerializer.getTupleClass()))
+                ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
+                : OuterSchemaCompatibility.INCOMPATIBLE;
+    }
+}

--- a/src/main/java/io/findify/flinkadt/api/serializer/ScalaCaseClassSerializerSnapshot.java
+++ b/src/main/java/io/findify/flinkadt/api/serializer/ScalaCaseClassSerializerSnapshot.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.findify.flinkadt.api.serializer;
 
 import org.apache.flink.annotation.Internal;

--- a/src/main/java/io/findify/flinkadt/api/serializer/ScalaCaseClassSerializerSnapshot.java
+++ b/src/main/java/io/findify/flinkadt/api/serializer/ScalaCaseClassSerializerSnapshot.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.findify.flinkadt.api.serializer;
 
 import org.apache.flink.annotation.Internal;

--- a/src/main/java/io/findify/flinkadt/api/serializer/ScalaEitherSerializerSnapshot.java
+++ b/src/main/java/io/findify/flinkadt/api/serializer/ScalaEitherSerializerSnapshot.java
@@ -1,0 +1,51 @@
+package io.findify.flinkadt.api.serializer;
+
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+
+import scala.util.Either;
+
+/**
+ * Configuration snapshot for serializers of Scala's {@link Either} type, containing configuration
+ * snapshots of the Left and Right serializers.
+ */
+public class ScalaEitherSerializerSnapshot<L, R>
+        extends CompositeTypeSerializerSnapshot<Either<L, R>, EitherSerializer<L, R>> {
+
+    private static final int CURRENT_VERSION = 1;
+
+    /** Constructor for read instantiation. */
+    public ScalaEitherSerializerSnapshot() {
+        super(EitherSerializer.class);
+    }
+
+    /** Constructor to create the snapshot for writing. */
+    public ScalaEitherSerializerSnapshot(EitherSerializer<L, R> eitherSerializer) {
+        super(eitherSerializer);
+    }
+
+    @Override
+    public int getCurrentOuterSnapshotVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    protected EitherSerializer<L, R> createOuterSerializerWithNestedSerializers(
+            TypeSerializer<?>[] nestedSerializers) {
+        @SuppressWarnings("unchecked")
+        TypeSerializer<L> leftSerializer = (TypeSerializer<L>) nestedSerializers[0];
+
+        @SuppressWarnings("unchecked")
+        TypeSerializer<R> rightSerializer = (TypeSerializer<R>) nestedSerializers[1];
+
+        return new EitherSerializer<>(leftSerializer, rightSerializer);
+    }
+
+    @Override
+    protected TypeSerializer<?>[] getNestedSerializers(EitherSerializer<L, R> outerSerializer) {
+        return new TypeSerializer<?>[] {
+                outerSerializer.getLeftSerializer(), outerSerializer.getRightSerializer()
+        };
+    }
+}
+

--- a/src/main/java/io/findify/flinkadt/api/serializer/ScalaEitherSerializerSnapshot.java
+++ b/src/main/java/io/findify/flinkadt/api/serializer/ScalaEitherSerializerSnapshot.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.findify.flinkadt.api.serializer;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;

--- a/src/main/java/io/findify/flinkadt/api/serializer/ScalaEitherSerializerSnapshot.java
+++ b/src/main/java/io/findify/flinkadt/api/serializer/ScalaEitherSerializerSnapshot.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.findify.flinkadt.api.serializer;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;

--- a/src/main/java/io/findify/flinkadt/api/serializer/ScalaOptionSerializerSnapshot.java
+++ b/src/main/java/io/findify/flinkadt/api/serializer/ScalaOptionSerializerSnapshot.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.findify.flinkadt.api.serializer;
+
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+
+import scala.Option;
+
+/** A {@link TypeSerializerSnapshot} for the Scala {@link OptionSerializer}. */
+public final class ScalaOptionSerializerSnapshot<E>
+        extends CompositeTypeSerializerSnapshot<Option<E>, OptionSerializer<E>> {
+
+    private static final int VERSION = 2;
+
+    @SuppressWarnings("WeakerAccess")
+    public ScalaOptionSerializerSnapshot() {
+        super(OptionSerializer.class);
+    }
+
+    public ScalaOptionSerializerSnapshot(OptionSerializer<E> serializerInstance) {
+        super(serializerInstance);
+    }
+
+    @Override
+    protected int getCurrentOuterSnapshotVersion() {
+        return VERSION;
+    }
+
+    @Override
+    protected TypeSerializer<?>[] getNestedSerializers(OptionSerializer<E> outerSerializer) {
+        return new TypeSerializer[] {outerSerializer.elemSerializer()};
+    }
+
+    @Override
+    protected OptionSerializer<E> createOuterSerializerWithNestedSerializers(
+            TypeSerializer<?>[] nestedSerializers) {
+        @SuppressWarnings("unchecked")
+        TypeSerializer<E> nestedSerializer = (TypeSerializer<E>) nestedSerializers[0];
+        return new OptionSerializer<>(nestedSerializer);
+    }
+}
+

--- a/src/main/scala/io/findify/flinkadt/api/package.scala
+++ b/src/main/scala/io/findify/flinkadt/api/package.scala
@@ -1,24 +1,14 @@
 package io.findify.flinkadt
 
 import io.findify.flinkadt.api.serializer._
-import io.findify.flinkadt.api.typeinfo.{CollectionTypeInformation, CoproductTypeInformation, ProductTypeInformation}
+import io.findify.flinkadt.api.typeinfo.{EitherTypeInfo, CollectionTypeInformation, CoproductTypeInformation, ProductTypeInformation}
 import magnolia1.{CaseClass, SealedTrait}
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.TypeSerializer
-import org.apache.flink.api.common.typeutils.base.array.{
-  BooleanPrimitiveArraySerializer,
-  BytePrimitiveArraySerializer,
-  CharPrimitiveArraySerializer,
-  DoublePrimitiveArraySerializer,
-  FloatPrimitiveArraySerializer,
-  IntPrimitiveArraySerializer,
-  LongPrimitiveArraySerializer,
-  ShortPrimitiveArraySerializer,
-  StringArraySerializer
-}
+import org.apache.flink.api.common.typeutils.base.array.{BooleanPrimitiveArraySerializer, BytePrimitiveArraySerializer, CharPrimitiveArraySerializer, DoublePrimitiveArraySerializer, FloatPrimitiveArraySerializer, IntPrimitiveArraySerializer, LongPrimitiveArraySerializer, ShortPrimitiveArraySerializer, StringArraySerializer}
 import org.apache.flink.api.scala.createTypeInformation
-import org.apache.flink.api.scala.typeutils.{EitherSerializer, OptionSerializer, OptionTypeInfo}
+import org.apache.flink.api.scala.typeutils.{OptionSerializer, OptionTypeInfo}
 
 import scala.language.experimental.macros
 import scala.reflect.runtime.universe._
@@ -227,4 +217,11 @@ package object api extends LowPrioImplicits {
 
   implicit def optionInfo[T](implicit ls: TypeInformation[T]): TypeInformation[Option[T]] =
     new OptionTypeInfo[T, Option[T]](ls)
+
+  implicit def eitherInfo[A, B](implicit
+    tag: ClassTag[Either[A, B]],
+    a: TypeInformation[A],
+    b: TypeInformation[B]
+  ): TypeInformation[Either[A, B]] =
+    new EitherTypeInfo(tag.runtimeClass.asInstanceOf[Class[Either[A, B]]], a, b)
 }

--- a/src/main/scala/io/findify/flinkadt/api/package.scala
+++ b/src/main/scala/io/findify/flinkadt/api/package.scala
@@ -1,13 +1,12 @@
 package io.findify.flinkadt
 
 import io.findify.flinkadt.api.serializer._
-import io.findify.flinkadt.api.typeinfo.{CollectionTypeInformation, CoproductTypeInformation, EitherTypeInfo, OptionTypeInfo, ProductTypeInformation}
+import io.findify.flinkadt.api.typeinfo._
 import magnolia1.{CaseClass, SealedTrait}
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.TypeSerializer
-import org.apache.flink.api.common.typeutils.base.array.{BooleanPrimitiveArraySerializer, BytePrimitiveArraySerializer, CharPrimitiveArraySerializer, DoublePrimitiveArraySerializer, FloatPrimitiveArraySerializer, IntPrimitiveArraySerializer, LongPrimitiveArraySerializer, ShortPrimitiveArraySerializer, StringArraySerializer}
-import org.apache.flink.api.scala.createTypeInformation
+import org.apache.flink.api.common.typeutils.base.array._
 
 import scala.language.experimental.macros
 import scala.reflect.runtime.universe._
@@ -162,14 +161,14 @@ package object api extends LowPrioImplicits {
 
   // type infos
   implicit lazy val stringInfo: TypeInformation[String] = BasicTypeInfo.STRING_TYPE_INFO
-  implicit lazy val intInfo: TypeInformation[Int]       = createTypeInformation[Int]
-  implicit lazy val boolInfo: TypeInformation[Boolean]  = createTypeInformation[Boolean]
-  implicit lazy val byteInfo: TypeInformation[Byte]     = createTypeInformation[Byte]
-  implicit lazy val charInfo: TypeInformation[Char]     = createTypeInformation[Char]
-  implicit lazy val doubleInfo: TypeInformation[Double] = createTypeInformation[Double]
-  implicit lazy val floatInfo: TypeInformation[Float]   = createTypeInformation[Float]
-  implicit lazy val longInfo: TypeInformation[Long]     = createTypeInformation[Long]
-  implicit lazy val shortInfo: TypeInformation[Short]   = createTypeInformation[Short]
+  implicit lazy val intInfo: TypeInformation[Int]       = BasicTypeInfo.getInfoFor(classOf[Int])
+  implicit lazy val boolInfo: TypeInformation[Boolean]  = BasicTypeInfo.getInfoFor(classOf[Boolean])
+  implicit lazy val byteInfo: TypeInformation[Byte]     = BasicTypeInfo.getInfoFor(classOf[Byte])
+  implicit lazy val charInfo: TypeInformation[Char]     = BasicTypeInfo.getInfoFor(classOf[Char])
+  implicit lazy val doubleInfo: TypeInformation[Double] = BasicTypeInfo.getInfoFor(classOf[Double])
+  implicit lazy val floatInfo: TypeInformation[Float]   = BasicTypeInfo.getInfoFor(classOf[Float])
+  implicit lazy val longInfo: TypeInformation[Long]     = BasicTypeInfo.getInfoFor(classOf[Long])
+  implicit lazy val shortInfo: TypeInformation[Short]   = BasicTypeInfo.getInfoFor(classOf[Short])
   // serializers
   implicit lazy val stringSerializer: TypeSerializer[String]   = stringInfo.createSerializer(config)
   implicit lazy val intSerializer: TypeSerializer[Int]         = intInfo.createSerializer(config)

--- a/src/main/scala/io/findify/flinkadt/api/package.scala
+++ b/src/main/scala/io/findify/flinkadt/api/package.scala
@@ -1,14 +1,13 @@
 package io.findify.flinkadt
 
 import io.findify.flinkadt.api.serializer._
-import io.findify.flinkadt.api.typeinfo.{EitherTypeInfo, CollectionTypeInformation, CoproductTypeInformation, ProductTypeInformation}
+import io.findify.flinkadt.api.typeinfo.{CollectionTypeInformation, CoproductTypeInformation, EitherTypeInfo, OptionTypeInfo, ProductTypeInformation}
 import magnolia1.{CaseClass, SealedTrait}
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.api.common.typeutils.base.array.{BooleanPrimitiveArraySerializer, BytePrimitiveArraySerializer, CharPrimitiveArraySerializer, DoublePrimitiveArraySerializer, FloatPrimitiveArraySerializer, IntPrimitiveArraySerializer, LongPrimitiveArraySerializer, ShortPrimitiveArraySerializer, StringArraySerializer}
 import org.apache.flink.api.scala.createTypeInformation
-import org.apache.flink.api.scala.typeutils.{OptionSerializer, OptionTypeInfo}
 
 import scala.language.experimental.macros
 import scala.reflect.runtime.universe._

--- a/src/main/scala/io/findify/flinkadt/api/serializer/CaseClassSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/CaseClassSerializer.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.findify.flinkadt.api.serializer
 
 import org.apache.flink.annotation.Internal

--- a/src/main/scala/io/findify/flinkadt/api/serializer/CaseClassSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/CaseClassSerializer.scala
@@ -1,0 +1,121 @@
+package io.findify.flinkadt.api.serializer
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializerBase
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+import org.apache.flink.types.NullFieldException
+
+/**
+ * Serializer for Case Classes. Creation and access is different from
+ * our Java Tuples so we have to treat them differently.
+ * Copied from Flink 1.14.
+ */
+@Internal
+@SerialVersionUID(7341356073446263475L)
+abstract class CaseClassSerializer[T <: Product](
+  clazz: Class[T],
+  scalaFieldSerializers: Array[TypeSerializer[_]]
+) extends TupleSerializerBase[T](clazz, scalaFieldSerializers)
+    with Cloneable {
+
+  @transient var fields: Array[AnyRef] = _
+
+  @transient var instanceCreationFailed: Boolean = false
+
+  override def duplicate: CaseClassSerializer[T] = {
+    clone().asInstanceOf[CaseClassSerializer[T]]
+  }
+
+  @throws[CloneNotSupportedException]
+  override protected def clone(): Object = {
+    val result = super.clone().asInstanceOf[CaseClassSerializer[T]]
+
+    // achieve a deep copy by duplicating the field serializers
+    result.fieldSerializers = result.fieldSerializers.map(_.duplicate())
+    result.fields = null
+    result.instanceCreationFailed = false
+
+    result
+  }
+
+  def createInstance: T = {
+    if (instanceCreationFailed) {
+      null.asInstanceOf[T]
+    }
+    else {
+      initArray()
+      try {
+        var i = 0
+        while (i < arity) {
+          fields(i) = fieldSerializers(i).createInstance()
+          i += 1
+        }
+        createInstance(fields)
+      }
+      catch {
+        case t: Throwable =>
+          instanceCreationFailed = true
+          null.asInstanceOf[T]
+      }
+    }
+  }
+
+  override def createOrReuseInstance(fields: Array[Object], reuse: T) : T = {
+    createInstance(fields)
+  }
+
+  def copy(from: T, reuse: T): T = {
+    copy(from)
+  }
+
+  def copy(from: T): T = {
+    if (from == null) {
+      null.asInstanceOf[T]
+    }
+    else {
+      initArray()
+      var i = 0
+      while (i < arity) {
+        fields(i) = fieldSerializers(i).copy(from.productElement(i).asInstanceOf[AnyRef])
+        i += 1
+      }
+      createInstance(fields)
+    }
+  }
+
+  def serialize(value: T, target: DataOutputView): Unit = {
+    var i = 0
+    while (i < arity) {
+      val serializer = fieldSerializers(i).asInstanceOf[TypeSerializer[Any]]
+      val o = value.productElement(i)
+      try
+        serializer.serialize(o, target)
+      catch {
+        case e: NullPointerException =>
+          throw new NullFieldException(i, e)
+      }
+      i += 1
+    }
+  }
+
+  def deserialize(reuse: T, source: DataInputView): T = {
+    deserialize(source)
+  }
+
+  def deserialize(source: DataInputView): T = {
+    initArray()
+    var i = 0
+    while (i < arity) {
+      fields(i) = fieldSerializers(i).deserialize(source)
+      i += 1
+    }
+    createInstance(fields)
+  }
+
+  def initArray(): Unit = {
+    if (fields == null) {
+      fields = new Array[AnyRef](arity)
+    }
+  }
+}

--- a/src/main/scala/io/findify/flinkadt/api/serializer/CoproductSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/CoproductSerializer.scala
@@ -1,14 +1,8 @@
 package io.findify.flinkadt.api.serializer
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
-import java.util
-
 import io.findify.flinkadt.api.serializer.CoproductSerializer.CoproductSerializerSnapshot
-import magnolia1.{SealedTrait, Subtype, TypeName}
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton
 import org.apache.flink.api.common.typeutils.{
-  GenericTypeSerializerSnapshot,
-  SimpleTypeSerializerSnapshot,
   TypeSerializer,
   TypeSerializerSchemaCompatibility,
   TypeSerializerSnapshot

--- a/src/main/scala/io/findify/flinkadt/api/serializer/EitherSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/EitherSerializer.scala
@@ -1,0 +1,108 @@
+package io.findify.flinkadt.api.serializer
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.typeutils._
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+
+/**
+ * Serializer for [[Either]].
+ * Copied from Flink 1.14.
+ */
+@Internal
+@SerialVersionUID(9219995873023657525L)
+class EitherSerializer[A, B](
+  val leftSerializer: TypeSerializer[A],
+  val rightSerializer: TypeSerializer[B]
+) extends TypeSerializer[Either[A, B]] {
+
+  override def duplicate: EitherSerializer[A,B] = {
+    val leftDup = leftSerializer.duplicate()
+    val rightDup = rightSerializer.duplicate()
+
+    if (leftDup.eq(leftSerializer) && rightDup.eq(rightSerializer)) {
+      this
+    } else {
+      new EitherSerializer[A, B](leftDup, rightDup)
+    }
+  }
+
+  override def createInstance: Either[A, B] = {
+    Left(null).asInstanceOf[Left[A, B]]
+  }
+
+  override def isImmutableType: Boolean = {
+    (leftSerializer == null || leftSerializer.isImmutableType) &&
+      (rightSerializer == null || rightSerializer.isImmutableType)
+  }
+
+  override def getLength: Int = -1
+
+  override def copy(from: Either[A, B]): Either[A, B] = from match {
+    case Left(a) => Left(leftSerializer.copy(a))
+    case Right(b) => Right(rightSerializer.copy(b))
+  }
+
+  override def copy(from: Either[A, B], reuse: Either[A, B]): Either[A, B] = copy(from)
+
+  override def copy(source: DataInputView, target: DataOutputView): Unit = {
+    val isLeft = source.readBoolean()
+    target.writeBoolean(isLeft)
+    if (isLeft) {
+      leftSerializer.copy(source, target)
+    } else {
+      rightSerializer.copy(source, target)
+    }
+  }
+
+  override def serialize(either: Either[A, B], target: DataOutputView): Unit = either match {
+    case Left(a) =>
+      target.writeBoolean(true)
+      leftSerializer.serialize(a, target)
+    case Right(b) =>
+      target.writeBoolean(false)
+      rightSerializer.serialize(b, target)
+  }
+
+  override def deserialize(source: DataInputView): Either[A, B] = {
+    val isLeft = source.readBoolean()
+    if (isLeft) {
+      Left(leftSerializer.deserialize(source))
+    } else {
+      Right(rightSerializer.deserialize(source))
+    }
+  }
+
+  override def deserialize(reuse: Either[A, B], source: DataInputView): Either[A, B] = {
+    val isLeft = source.readBoolean()
+    if (isLeft) {
+      Left(leftSerializer.deserialize(source))
+    } else {
+      Right(rightSerializer.deserialize(source))
+    }
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case eitherSerializer: EitherSerializer[_, _] =>
+        leftSerializer.equals(eitherSerializer.leftSerializer) &&
+          rightSerializer.equals(eitherSerializer.rightSerializer)
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = {
+    31 * leftSerializer.hashCode() + rightSerializer.hashCode()
+  }
+
+  def getLeftSerializer: TypeSerializer[A] = leftSerializer
+
+  def getRightSerializer: TypeSerializer[B] = rightSerializer
+
+  // --------------------------------------------------------------------------------------------
+  // Serializer configuration snapshotting & compatibility
+  // --------------------------------------------------------------------------------------------
+
+  override def snapshotConfiguration(): ScalaEitherSerializerSnapshot[A, B] = {
+    new ScalaEitherSerializerSnapshot[A, B](this)
+  }
+}

--- a/src/main/scala/io/findify/flinkadt/api/serializer/EitherSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/EitherSerializer.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.findify.flinkadt.api.serializer
 
 import org.apache.flink.annotation.Internal

--- a/src/main/scala/io/findify/flinkadt/api/serializer/NothingSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/NothingSerializer.scala
@@ -1,0 +1,63 @@
+package io.findify.flinkadt.api.serializer
+
+import java.util.function.Supplier
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.typeutils.{SimpleTypeSerializerSnapshot, TypeSerializer, TypeSerializerSnapshot}
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+
+/**
+ * Serializer for cases where no serializer is required but the system still expects one. This
+ * happens for OptionTypeInfo when None is used, or for Either when one of the type parameters
+ * is Nothing.
+ */
+@Internal
+class NothingSerializer extends TypeSerializer[Any] {
+
+  override def duplicate: NothingSerializer = this
+
+  override def createInstance: Any = {
+    Integer.valueOf(-1)
+  }
+
+  override def isImmutableType: Boolean = true
+
+  override def getLength: Int = -1
+
+  override def copy(from: Any): Any =
+    throw new RuntimeException("This must not be used. You encountered a bug.")
+
+  override def copy(from: Any, reuse: Any): Any = copy(from)
+
+  override def copy(source: DataInputView, target: DataOutputView): Unit =
+    throw new RuntimeException("This must not be used. You encountered a bug.")
+
+  override def serialize(any: Any, target: DataOutputView): Unit =
+    throw new RuntimeException("This must not be used. You encountered a bug.")
+
+  override def deserialize(source: DataInputView): Any =
+    throw new RuntimeException("This must not be used. You encountered a bug.")
+
+  override def deserialize(reuse: Any, source: DataInputView): Any =
+    throw new RuntimeException("This must not be used. You encountered a bug.")
+
+  override def snapshotConfiguration(): TypeSerializerSnapshot[Any] =
+    new NothingSerializerSnapshot
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case _: NothingSerializer => true
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = {
+    classOf[NothingSerializer].hashCode()
+  }
+}
+
+class NothingSerializerSnapshot extends SimpleTypeSerializerSnapshot[Any](
+  new Supplier[TypeSerializer[Any]] {
+    override def get(): TypeSerializer[Any] = new NothingSerializer
+  }
+)

--- a/src/main/scala/io/findify/flinkadt/api/serializer/NothingSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/NothingSerializer.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.findify.flinkadt.api.serializer
 
 import java.util.function.Supplier

--- a/src/main/scala/io/findify/flinkadt/api/serializer/OptionSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/OptionSerializer.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.findify.flinkadt.api.serializer
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.typeutils._
+import org.apache.flink.core.memory.{DataInputView, DataOutputView}
+
+/**
+ * Serializer for [[Option]].
+ */
+@Internal
+@SerialVersionUID(-8635243274072627338L)
+class OptionSerializer[A](val elemSerializer: TypeSerializer[A])
+  extends TypeSerializer[Option[A]] {
+
+  override def duplicate: OptionSerializer[A] = {
+    val duplicatedElemSerializer = elemSerializer.duplicate()
+
+    if (duplicatedElemSerializer.eq(elemSerializer)) {
+      this
+    } else {
+      new OptionSerializer[A](duplicatedElemSerializer)
+    }
+  }
+
+  override def createInstance: Option[A] = {
+    None
+  }
+
+  override def isImmutableType: Boolean = elemSerializer == null || elemSerializer.isImmutableType
+
+  override def getLength: Int = -1
+
+  override def copy(from: Option[A]): Option[A] = from match {
+    case Some(a) => Some(elemSerializer.copy(a))
+    case None => from
+  }
+
+  override def copy(from: Option[A], reuse: Option[A]): Option[A] = copy(from)
+
+  override def copy(source: DataInputView, target: DataOutputView): Unit = {
+    val isSome = source.readBoolean()
+    target.writeBoolean(isSome)
+    if (isSome) {
+      elemSerializer.copy(source, target)
+    }
+  }
+
+  override def serialize(either: Option[A], target: DataOutputView): Unit = either match {
+    case Some(a) =>
+      target.writeBoolean(true)
+      elemSerializer.serialize(a, target)
+    case None =>
+      target.writeBoolean(false)
+  }
+
+  override def deserialize(source: DataInputView): Option[A] = {
+    val isSome = source.readBoolean()
+    if (isSome) {
+      Some(elemSerializer.deserialize(source))
+    } else {
+      None
+    }
+  }
+
+  override def deserialize(reuse: Option[A], source: DataInputView): Option[A] = deserialize(source)
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case optionSerializer: OptionSerializer[_] =>
+        elemSerializer.equals(optionSerializer.elemSerializer)
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = {
+    elemSerializer.hashCode()
+  }
+
+  // --------------------------------------------------------------------------------------------
+  // Serializer configuration snapshotting & compatibility
+  // --------------------------------------------------------------------------------------------
+
+  override def snapshotConfiguration(): TypeSerializerSnapshot[Option[A]] = {
+    new ScalaOptionSerializerSnapshot[A](this)
+  }
+}

--- a/src/main/scala/io/findify/flinkadt/api/serializer/ScalaCaseClassSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/ScalaCaseClassSerializer.scala
@@ -1,0 +1,72 @@
+package io.findify.flinkadt.api.serializer
+
+import io.findify.flinkadt.api.serializer.ScalaCaseClassSerializer.lookupConstructor
+import org.apache.flink.api.common.typeutils.{TypeSerializer, TypeSerializerSnapshot}
+
+import java.io.ObjectInputStream
+
+import scala.annotation.nowarn
+import scala.reflect.runtime.universe
+
+/**
+ * This is a non macro-generated, concrete Scala case class serializer.
+ * Copied from Flink 1.14 without `SelfResolvingTypeSerializer`.
+ */
+@SerialVersionUID(1L)
+class ScalaCaseClassSerializer[T <: Product](
+  clazz: Class[T],
+  scalaFieldSerializers: Array[TypeSerializer[_]]
+) extends CaseClassSerializer[T](clazz, scalaFieldSerializers) {
+
+  @transient
+  private var constructor = lookupConstructor(clazz)
+
+  override def createInstance(fields: Array[AnyRef]): T = {
+    constructor(fields)
+  }
+
+  override def snapshotConfiguration(): TypeSerializerSnapshot[T] =
+    new ScalaCaseClassSerializerSnapshot[T](this)
+
+  // Do NOT delete this method, it is used by ser/de even though it is private.
+  // This should be removed once we make sure that serializer are no long java serialized.
+  private def readObject(in: ObjectInputStream): Unit = {
+    in.defaultReadObject()
+    constructor = lookupConstructor(clazz)
+  }
+}
+
+object ScalaCaseClassSerializer {
+  @nowarn("msg=eliminated by erasure")
+  def lookupConstructor[T](cls: Class[T]): Array[AnyRef] => T = {
+    val rootMirror = universe.runtimeMirror(cls.getClassLoader)
+    val classSymbol = rootMirror.classSymbol(cls)
+
+    require(
+      classSymbol.isStatic,
+      s"""
+         |The class ${cls.getSimpleName} is an instance class, meaning it is not a member of a
+         |toplevel object, or of an object contained in a toplevel object,
+         |therefore it requires an outer instance to be instantiated, but we don't have a
+         |reference to the outer instance. Please consider changing the outer class to an object.
+         |""".stripMargin
+    )
+
+    val primaryConstructorSymbol = classSymbol.toType
+      .decl(universe.termNames.CONSTRUCTOR)
+      .alternatives
+      .collectFirst {
+        case constructorSymbol: universe.MethodSymbol if constructorSymbol.isPrimaryConstructor =>
+          constructorSymbol
+      }
+      .head
+      .asMethod
+
+    val classMirror = rootMirror.reflectClass(classSymbol)
+    val constructorMethodMirror = classMirror.reflectConstructor(primaryConstructorSymbol)
+
+    arr: Array[AnyRef] => {
+      constructorMethodMirror.apply(arr: _*).asInstanceOf[T]
+    }
+  }
+}

--- a/src/main/scala/io/findify/flinkadt/api/serializer/ScalaCaseClassSerializer.scala
+++ b/src/main/scala/io/findify/flinkadt/api/serializer/ScalaCaseClassSerializer.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.findify.flinkadt.api.serializer
 
 import io.findify.flinkadt.api.serializer.ScalaCaseClassSerializer.lookupConstructor

--- a/src/main/scala/io/findify/flinkadt/api/typeinfo/CaseClassComparator.scala
+++ b/src/main/scala/io/findify/flinkadt/api/typeinfo/CaseClassComparator.scala
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.findify.flinkadt.api.typeinfo
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.typeutils.{TypeComparator, TypeSerializer}
+import org.apache.flink.api.java.typeutils.runtime.TupleComparatorBase
+import org.apache.flink.core.memory.MemorySegment
+import org.apache.flink.types.{KeyFieldOutOfBoundsException, NullKeyFieldException}
+
+/**
+ * Comparator for Case Classes. Access is different from
+ * our Java Tuples so we have to treat them differently.
+ */
+@Internal
+class CaseClassComparator[T <: Product](
+  keys: Array[Int],
+  scalaComparators: Array[TypeComparator[_]],
+  scalaSerializers: Array[TypeSerializer[_]]
+) extends TupleComparatorBase[T](keys, scalaComparators, scalaSerializers) {
+
+  private val extractedKeys = new Array[AnyRef](keys.length)
+
+  // We cannot use the Clone Constructor from Scala so we have to do it manually
+  def duplicate: TypeComparator[T] = {
+    // ensure that the serializers are available
+    instantiateDeserializationUtils()
+    val result = new CaseClassComparator[T](keyPositions, comparators, serializers)
+    result.privateDuplicate(this)
+    result
+  }
+
+  // --------------------------------------------------------------------------------------------
+  //  Comparator Methods
+  // --------------------------------------------------------------------------------------------
+
+  def hash(value: T): Int = {
+    val comparator = comparators(0).asInstanceOf[TypeComparator[Any]]
+    var code: Int = comparator.hash(value.productElement(keyPositions(0)))
+    var i = 1
+    try {
+      while(i < keyPositions.length) {
+        code *= TupleComparatorBase.HASH_SALT(i & 0x1F)
+        val comparator = comparators(i).asInstanceOf[TypeComparator[Any]]
+        code += comparator.hash(value.productElement(keyPositions(i)))
+        i += 1
+      }
+    } catch {
+      case _: NullPointerException =>
+        throw new NullKeyFieldException(keyPositions(i))
+      case _: IndexOutOfBoundsException =>
+        throw new KeyFieldOutOfBoundsException(keyPositions(i))
+    }
+    code
+  }
+
+  def setReference(toCompare: T): Unit = {
+    var i = 0
+    try {
+      while(i < keyPositions.length) {
+        val comparator = comparators(i).asInstanceOf[TypeComparator[Any]]
+        comparator.setReference(toCompare.productElement(keyPositions(i)))
+        i += 1
+      }
+    } catch {
+      case _: NullPointerException =>
+        throw new NullKeyFieldException(keyPositions(i))
+      case _: IndexOutOfBoundsException =>
+        throw new KeyFieldOutOfBoundsException(keyPositions(i))
+    }
+  }
+
+  def equalToReference(candidate: T): Boolean = {
+    var i = 0
+    try {
+      while(i < keyPositions.length) {
+        val comparator = comparators(i).asInstanceOf[TypeComparator[Any]]
+        if (!comparator.equalToReference(candidate.productElement(keyPositions(i)))) {
+          return false
+        }
+        i += 1
+      }
+    } catch {
+      case _: NullPointerException =>
+        throw new NullKeyFieldException(keyPositions(i))
+      case _: IndexOutOfBoundsException =>
+        throw new KeyFieldOutOfBoundsException(keyPositions(i))
+    }
+    true
+  }
+
+  def compare(first: T, second: T): Int = {
+    var i = 0
+    try {
+      while(i < keyPositions.length) {
+        val keyPos: Int = keyPositions(i)
+        val comparator = comparators(i).asInstanceOf[TypeComparator[Any]]
+        val cmp: Int = comparator.compare(
+          first.productElement(keyPos),
+          second.productElement(keyPos))
+        if (cmp != 0) {
+          return cmp
+        }
+        i += 1
+      }
+    } catch {
+      case _: NullPointerException =>
+        throw new NullKeyFieldException(keyPositions(i))
+      case _: IndexOutOfBoundsException =>
+        throw new KeyFieldOutOfBoundsException(keyPositions(i))
+    }
+    0
+  }
+
+  def putNormalizedKey(value: T, target: MemorySegment, offsetParam: Int, numBytesParam: Int): Unit = {
+    var numBytes = numBytesParam
+    var offset = offsetParam
+    var i: Int = 0
+    try {
+      while (i < numLeadingNormalizableKeys && numBytes > 0) {
+        {
+          var len: Int = normalizedKeyLengths(i)
+          len = if (numBytes >= len) len else numBytes
+          val comparator = comparators(i).asInstanceOf[TypeComparator[Any]]
+          comparator.putNormalizedKey(value.productElement(keyPositions(i)), target, offset, len)
+          numBytes -= len
+          offset += len
+        }
+        i += 1
+      }
+    } catch {
+      case npex: NullPointerException => throw new NullKeyFieldException(keyPositions(i))
+    }
+  }
+
+  def extractKeys(value: AnyRef, target: Array[AnyRef], index: Int): Int = {
+    val in = value.asInstanceOf[T]
+
+    var localIndex: Int = index
+    var i = 0
+    while (i < comparators.length) {
+      localIndex += comparators(i).extractKeys(
+        in.productElement(keyPositions(i)),
+        target,
+        localIndex)
+
+      i += 1
+    }
+
+    localIndex - index
+  }
+}

--- a/src/main/scala/io/findify/flinkadt/api/typeinfo/CaseClassTypeInfo.scala
+++ b/src/main/scala/io/findify/flinkadt/api/typeinfo/CaseClassTypeInfo.scala
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.findify.flinkadt.api.typeinfo
+
+import java.util
+import java.util.regex.{Matcher, Pattern}
+import org.apache.flink.annotation.{Public, PublicEvolving}
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.operators.Keys
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.CompositeType.{FlatFieldDescriptor, InvalidFieldReferenceException, TypeComparatorBuilder}
+import org.apache.flink.api.common.typeutils._
+import Keys.ExpressionKeys
+import org.apache.flink.api.java.typeutils.TupleTypeInfoBase
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * TypeInformation for Case Classes. Creation and access is different from
+ * our Java Tuples so we have to treat them differently.
+ */
+@Public
+abstract class CaseClassTypeInfo[T <: Product](
+  clazz: Class[T],
+  val typeParamTypeInfos: Array[TypeInformation[_]],
+  fieldTypes: Seq[TypeInformation[_]],
+  val fieldNames: Seq[String]
+) extends TupleTypeInfoBase[T](clazz, fieldTypes: _*) {
+
+  @PublicEvolving
+  override def getGenericParameters: java.util.Map[String, TypeInformation[_]] = {
+    typeParamTypeInfos.zipWithIndex.map { case (info, index) =>
+      "T" + (index + 1) -> info
+    }.toMap[String, TypeInformation[_]].asJava
+  }
+
+  private val REGEX_INT_FIELD: String = "[0-9]+"
+  private val REGEX_STR_FIELD: String = "[\\p{L}_\\$][\\p{L}\\p{Digit}_\\$]*"
+  private val REGEX_FIELD: String = REGEX_STR_FIELD + "|" + REGEX_INT_FIELD
+  private val REGEX_NESTED_FIELDS: String = "(" + REGEX_FIELD + ")(\\.(.+))?"
+  private val REGEX_NESTED_FIELDS_WILDCARD: String = REGEX_NESTED_FIELDS + "|\\" +
+    ExpressionKeys.SELECT_ALL_CHAR + "|\\" + ExpressionKeys.SELECT_ALL_CHAR_SCALA
+
+  private val PATTERN_NESTED_FIELDS: Pattern = Pattern.compile(REGEX_NESTED_FIELDS)
+  private val PATTERN_NESTED_FIELDS_WILDCARD: Pattern =
+    Pattern.compile(REGEX_NESTED_FIELDS_WILDCARD)
+  private val PATTERN_INT_FIELD: Pattern = Pattern.compile(REGEX_INT_FIELD)
+
+  @PublicEvolving
+  def getFieldIndices(fields: Array[String]): Array[Int] = {
+    fields map { x => fieldNames.indexOf(x) }
+  }
+
+  @PublicEvolving
+  override def getFlatFields(
+    fieldExpression: String,
+    offset: Int,
+    result: java.util.List[FlatFieldDescriptor]
+  ): Unit = {
+    val matcher: Matcher = PATTERN_NESTED_FIELDS_WILDCARD.matcher(fieldExpression)
+
+    if (!matcher.matches) {
+      throw new InvalidFieldReferenceException("Invalid tuple field reference \"" +
+        fieldExpression + "\".")
+    }
+
+    var field: String = matcher.group(0)
+
+    if ((field == ExpressionKeys.SELECT_ALL_CHAR) ||
+      (field == ExpressionKeys.SELECT_ALL_CHAR_SCALA)) {
+      var keyPosition: Int = 0
+      for (fType <- fieldTypes) {
+        fType match {
+          case ct: CompositeType[_] =>
+            ct.getFlatFields(ExpressionKeys.SELECT_ALL_CHAR, offset + keyPosition, result)
+            keyPosition += ct.getTotalFields - 1
+          case _ =>
+            result.add(new FlatFieldDescriptor(offset + keyPosition, fType))
+        }
+        keyPosition += 1
+      }
+    } else {
+      field = matcher.group(1)
+
+      val intFieldMatcher = PATTERN_INT_FIELD.matcher(field)
+      if(intFieldMatcher.matches()) {
+        // convert 0-indexed integer field into 1-indexed name field
+        field = "_" + (Integer.valueOf(field) + 1)
+      }
+
+      val tail = matcher.group(3)
+
+      if (tail == null) {
+        @tailrec
+        def extractFlatFields(index: Int, pos: Int): Unit = {
+          if (index >= fieldNames.size) {
+            throw new InvalidFieldReferenceException("Unable to find field \"" + field +
+              "\" in type " + this + ".")
+          } else if (field == fieldNames(index)) {
+            // found field
+            fieldTypes(index) match {
+              case ct: CompositeType[_] =>
+                ct.getFlatFields("*", pos, result)
+              case _ =>
+                result.add(new FlatFieldDescriptor(pos, fieldTypes(index)))
+            }
+          } else {
+            // skipping over non-matching fields
+            extractFlatFields(index + 1, pos + fieldTypes(index).getTotalFields())
+          }
+        }
+
+        extractFlatFields(0, offset)
+      } else {
+        @tailrec
+        def extractFlatFields(index: Int, pos: Int): Unit = {
+          if (index >= fieldNames.size) {
+            throw new InvalidFieldReferenceException("Unable to find field \"" + field +
+              "\" in type " + this + ".")
+          } else if (field == fieldNames(index)) {
+            // found field
+            fieldTypes(index) match {
+              case ct: CompositeType[_] =>
+                ct.getFlatFields(tail, pos, result)
+              case _ =>
+                throw new InvalidFieldReferenceException("Nested field expression \"" + tail +
+                  "\" not possible on atomic type " + fieldTypes(index) + ".")
+            }
+          } else {
+            extractFlatFields(index + 1, pos + fieldTypes(index).getTotalFields())
+          }
+        }
+
+        extractFlatFields(0, offset)
+      }
+    }
+  }
+
+  @PublicEvolving
+  override def getTypeAt[X](fieldExpression: String) : TypeInformation[X] = {
+    val matcher: Matcher = PATTERN_NESTED_FIELDS.matcher(fieldExpression)
+    if (!matcher.matches) {
+      if (fieldExpression.startsWith(ExpressionKeys.SELECT_ALL_CHAR) ||
+        fieldExpression.startsWith(ExpressionKeys.SELECT_ALL_CHAR_SCALA)) {
+        throw new InvalidFieldReferenceException("Wildcard expressions are not allowed here.")
+      }
+      else {
+        throw new InvalidFieldReferenceException("Invalid format of case class field expression \""
+          + fieldExpression + "\".")
+      }
+    }
+
+    var field = matcher.group(1)
+    val tail = matcher.group(3)
+
+    val intFieldMatcher = PATTERN_INT_FIELD.matcher(field)
+    if(intFieldMatcher.matches()) {
+      // convert 0-indexed integer field into 1-indexed name field
+      field = "_" + (Integer.valueOf(field) + 1)
+    }
+
+    for (i <- fieldNames.indices) {
+      if (fieldNames(i) == field) {
+        if (tail == null) {
+          return getTypeAt(i)
+        } else {
+          fieldTypes(i) match {
+            case co: CompositeType[_] =>
+              return co.getTypeAt(tail)
+            case _ =>
+              throw new InvalidFieldReferenceException("Nested field expression \"" + tail +
+                "\" not possible on atomic type " + fieldTypes(i) + ".")
+          }
+        }
+      }
+    }
+    throw new InvalidFieldReferenceException("Unable to find field \"" + field +
+      "\" in type " + this + ".")
+  }
+
+  @PublicEvolving
+  override def getFieldNames: Array[String] = fieldNames.toArray
+
+  @PublicEvolving
+  override def getFieldIndex(fieldName: String): Int = {
+    val result = fieldNames.indexOf(fieldName)
+    if (result != fieldNames.lastIndexOf(fieldName)) {
+      -1
+    } else {
+      result
+    }
+  }
+
+  @PublicEvolving
+  override def createTypeComparatorBuilder(): TypeComparatorBuilder[T] = {
+    new CaseClassTypeComparatorBuilder
+  }
+
+  private class CaseClassTypeComparatorBuilder extends TypeComparatorBuilder[T] {
+    val fieldComparators: ArrayBuffer[TypeComparator[_]] = new ArrayBuffer[TypeComparator[_]]()
+    val logicalKeyFields: ArrayBuffer[Int] = new ArrayBuffer[Int]()
+
+    override def initializeTypeComparatorBuilder(size: Int): Unit = {
+      fieldComparators.sizeHint(size)
+      logicalKeyFields.sizeHint(size)
+    }
+
+    override def addComparatorField(fieldId: Int, comparator: TypeComparator[_]): Unit = {
+      fieldComparators += comparator
+      logicalKeyFields += fieldId
+    }
+
+    override def createTypeComparator(config: ExecutionConfig): TypeComparator[T] = {
+      val maxIndex = logicalKeyFields.max
+
+      new CaseClassComparator[T](
+        logicalKeyFields.toArray,
+        fieldComparators.toArray,
+        types.take(maxIndex + 1).map(_.createSerializer(config))
+      )
+    }
+  }
+
+  override def toString: String = {
+    clazz.getName + "(" + fieldNames.zip(types).map {
+      case (n, t) => n + ": " + t
+    }.mkString(", ") + ")"
+  }
+
+  override def isCaseClass = true
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case caseClass: CaseClassTypeInfo[_] =>
+        caseClass.canEqual(this) &&
+          super.equals(caseClass) &&
+          typeParamTypeInfos.sameElements(caseClass.typeParamTypeInfos) &&
+          fieldNames.equals(caseClass.fieldNames)
+      case _ => false
+    }
+  }
+
+  override def hashCode(): Int = {
+    31 * (31 * super.hashCode() + fieldNames.hashCode()) +
+      util.Arrays.hashCode(typeParamTypeInfos.asInstanceOf[Array[AnyRef]])
+  }
+
+  override def canEqual(obj: Any): Boolean = {
+    obj.isInstanceOf[CaseClassTypeInfo[_]]
+  }
+}

--- a/src/main/scala/io/findify/flinkadt/api/typeinfo/EitherTypeInfo.scala
+++ b/src/main/scala/io/findify/flinkadt/api/typeinfo/EitherTypeInfo.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.findify.flinkadt.api.typeinfo
 
 import io.findify.flinkadt.api.serializer.{EitherSerializer, NothingSerializer}

--- a/src/main/scala/io/findify/flinkadt/api/typeinfo/EitherTypeInfo.scala
+++ b/src/main/scala/io/findify/flinkadt/api/typeinfo/EitherTypeInfo.scala
@@ -1,0 +1,73 @@
+package io.findify.flinkadt.api.typeinfo
+
+import io.findify.flinkadt.api.serializer.{EitherSerializer, NothingSerializer}
+import org.apache.flink.annotation.{Public, PublicEvolving}
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.TypeSerializer
+
+import scala.collection.JavaConverters._
+
+/**
+ * TypeInformation [[Either]].
+ */
+@Public
+class EitherTypeInfo[A, B, T <: Either[A, B]](
+  val clazz: Class[T],
+  val leftTypeInfo: TypeInformation[A],
+  val rightTypeInfo: TypeInformation[B]
+) extends TypeInformation[T] {
+
+  @PublicEvolving
+  override def isBasicType: Boolean = false
+  @PublicEvolving
+  override def isTupleType: Boolean = false
+  @PublicEvolving
+  override def isKeyType: Boolean = false
+  @PublicEvolving
+  override def getTotalFields: Int = 1
+  @PublicEvolving
+  override def getArity: Int = 1
+  @PublicEvolving
+  override def getTypeClass: Class[T] = clazz
+  @PublicEvolving
+  override def getGenericParameters: java.util.Map[String, TypeInformation[_]] =
+    Map[String, TypeInformation[_]]("A" -> leftTypeInfo, "B" -> rightTypeInfo).asJava
+
+  @PublicEvolving
+  def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[T] = {
+    val leftSerializer: TypeSerializer[A] = if (leftTypeInfo != null) {
+      leftTypeInfo.createSerializer(executionConfig)
+    } else {
+      (new NothingSerializer).asInstanceOf[TypeSerializer[A]]
+    }
+
+    val rightSerializer: TypeSerializer[B] = if (rightTypeInfo != null) {
+      rightTypeInfo.createSerializer(executionConfig)
+    } else {
+      (new NothingSerializer).asInstanceOf[TypeSerializer[B]]
+    }
+    new EitherSerializer[A, B](leftSerializer, rightSerializer).asInstanceOf[TypeSerializer[T]]
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case eitherTypeInfo: EitherTypeInfo[_, _, _] =>
+        eitherTypeInfo.canEqual(this) &&
+          clazz.equals(eitherTypeInfo.clazz) &&
+          leftTypeInfo.equals(eitherTypeInfo.leftTypeInfo) &&
+          rightTypeInfo.equals(eitherTypeInfo.rightTypeInfo)
+      case _ => false
+    }
+  }
+
+  override def canEqual(obj: Any): Boolean = {
+    obj.isInstanceOf[EitherTypeInfo[_, _, _]]
+  }
+
+  override def hashCode(): Int = {
+    31 * (31 * clazz.hashCode() + leftTypeInfo.hashCode()) + rightTypeInfo.hashCode()
+  }
+
+  override def toString = s"Either[$leftTypeInfo, $rightTypeInfo]"
+}

--- a/src/main/scala/io/findify/flinkadt/api/typeinfo/OptionTypeComparator.scala
+++ b/src/main/scala/io/findify/flinkadt/api/typeinfo/OptionTypeComparator.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.findify.flinkadt.api.typeinfo
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.typeutils.TypeComparator
+import org.apache.flink.core.memory.{DataInputView, DataOutputView, MemorySegment}
+
+/**
+ * Comparator for [[Option]] values. Note that [[None]] is lesser than any [[Some]] values.
+ */
+@Internal
+class OptionTypeComparator[A](ascending: Boolean, typeComparator: TypeComparator[A])
+  extends TypeComparator[Option[A]] {
+  private var reference: Option[A] = _
+
+  override def hash(record: Option[A]): Int = record.hashCode()
+
+  override def compare(first: Option[A], second: Option[A]): Int = {
+    first match {
+      case Some(firstValue) =>
+        second match {
+          case Some(secondValue) => typeComparator.compare(firstValue, secondValue)
+          case None =>
+            if (ascending) {
+              1
+            } else {
+              -1
+            }
+        }
+      case None =>
+        second match {
+          case Some(_) =>
+            if (ascending) {
+              -1
+            } else {
+              1
+            }
+          case None => 0
+        }
+    }
+  }
+
+  override def compareSerialized(firstSource: DataInputView, secondSource: DataInputView): Int = {
+    val firstSome = firstSource.readBoolean()
+    val secondSome = secondSource.readBoolean()
+
+    if (firstSome) {
+      if (secondSome) {
+        typeComparator.compareSerialized(firstSource, secondSource)
+      } else {
+        if (ascending) {
+          1
+        } else {
+          -1
+        }
+      }
+    } else {
+      if (secondSome) {
+        if (ascending) {
+          -1
+        } else {
+          1
+        }
+      } else {
+        0
+      }
+    }
+  }
+
+  override def extractKeys(record: AnyRef, target: Array[AnyRef], index: Int): Int = {
+    target(index) = record
+    1
+  }
+
+  override def setReference(toCompare: Option[A]): Unit = {
+    reference = toCompare
+  }
+
+  override def equalToReference(candidate: Option[A]): Boolean = {
+    compare(reference, candidate) == 0
+  }
+
+  override def compareToReference(referencedComparator: TypeComparator[Option[A]]): Int = {
+    compare(referencedComparator.asInstanceOf[this.type].reference, reference)
+  }
+
+  override lazy val getFlatComparators: Array[TypeComparator[_]] = {
+    Array(this).asInstanceOf[Array[TypeComparator[_]]]
+  }
+
+  override def getNormalizeKeyLen: Int = 1 + typeComparator.getNormalizeKeyLen
+
+  override def putNormalizedKey(
+    record: Option[A],
+    target: MemorySegment,
+    offset: Int,
+    numBytes: Int
+  ): Unit = {
+    if (numBytes >= 1) {
+      record match {
+        case Some(v) =>
+          target.put(offset, OptionTypeComparator.OneInByte)
+          typeComparator.putNormalizedKey(v, target, offset + 1, numBytes - 1)
+        case None =>
+          target.put(offset, OptionTypeComparator.ZeroInByte)
+          var i = 1
+          while (i < numBytes) {
+            target.put(offset + i, OptionTypeComparator.ZeroInByte)
+            i += 1
+          }
+      }
+    }
+  }
+
+  override def invertNormalizedKey(): Boolean = !ascending
+
+  override def readWithKeyDenormalization(reuse: Option[A], source: DataInputView): Option[A] = {
+    throw new UnsupportedOperationException
+  }
+
+  override def writeWithKeyNormalization(record: Option[A], target: DataOutputView): Unit = {
+    throw new UnsupportedOperationException
+  }
+
+  override def isNormalizedKeyPrefixOnly(keyBytes: Int): Boolean = {
+    typeComparator.isNormalizedKeyPrefixOnly(keyBytes - 1)
+  }
+
+  override def supportsSerializationWithKeyNormalization() = false
+
+  override def supportsNormalizedKey(): Boolean = typeComparator.supportsNormalizedKey()
+
+  override def duplicate() = new OptionTypeComparator[A](ascending, typeComparator)
+}
+
+object OptionTypeComparator {
+  val ZeroInByte: Byte = 0.asInstanceOf[Byte]
+  val OneInByte: Byte = 1.asInstanceOf[Byte]
+}

--- a/src/main/scala/io/findify/flinkadt/api/typeinfo/OptionTypeInfo.scala
+++ b/src/main/scala/io/findify/flinkadt/api/typeinfo/OptionTypeInfo.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.findify.flinkadt.api.typeinfo
+
+import io.findify.flinkadt.api.serializer.{NothingSerializer, OptionSerializer}
+import org.apache.flink.annotation.{Public, PublicEvolving, VisibleForTesting}
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.typeinfo.{AtomicType, TypeInformation}
+import org.apache.flink.api.common.typeutils.{TypeComparator, TypeSerializer}
+
+import scala.collection.JavaConverters._
+
+/**
+ * TypeInformation for [[Option]].
+ */
+@Public
+class OptionTypeInfo[A, T <: Option[A]](private val elemTypeInfo: TypeInformation[A])
+  extends TypeInformation[T] with AtomicType[T] {
+
+  @PublicEvolving
+  override def isBasicType: Boolean = false
+  @PublicEvolving
+  override def isTupleType: Boolean = false
+  @PublicEvolving
+  override def isKeyType: Boolean = elemTypeInfo.isKeyType
+  @PublicEvolving
+  override def getTotalFields: Int = 1
+  @PublicEvolving
+  override def getArity: Int = 1
+  @PublicEvolving
+  override def getTypeClass: Class[T] = classOf[Option[_]].asInstanceOf[Class[T]]
+  @PublicEvolving
+  override def getGenericParameters: java.util.Map[String, TypeInformation[_]] =
+    Map[String, TypeInformation[_]]("A" -> elemTypeInfo).asJava
+
+  @PublicEvolving
+  override def createComparator(ascending: Boolean, executionConfig: ExecutionConfig): TypeComparator[T] = {
+    if (isKeyType) {
+      val elemCompartor = elemTypeInfo.asInstanceOf[AtomicType[A]]
+        .createComparator(ascending, executionConfig)
+      new OptionTypeComparator[A](ascending, elemCompartor).asInstanceOf[TypeComparator[T]]
+    } else {
+      throw new UnsupportedOperationException("Element type that doesn't support ")
+    }
+  }
+
+  @PublicEvolving
+  def createSerializer(executionConfig: ExecutionConfig): TypeSerializer[T] = {
+    if (elemTypeInfo == null) {
+      // this happens when the type of a DataSet is None, i.e. DataSet[None]
+      new OptionSerializer(new NothingSerializer).asInstanceOf[TypeSerializer[T]]
+    } else {
+      new OptionSerializer(elemTypeInfo.createSerializer(executionConfig))
+        .asInstanceOf[TypeSerializer[T]]
+    }
+  }
+
+  override def toString = s"Option[$elemTypeInfo]"
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case optTpe: OptionTypeInfo[_, _] =>
+        optTpe.canEqual(this) && elemTypeInfo.equals(optTpe.elemTypeInfo)
+      case _ => false
+    }
+  }
+
+  def canEqual(obj: Any): Boolean = {
+    obj.isInstanceOf[OptionTypeInfo[_, _]]
+  }
+
+  override def hashCode: Int = {
+    elemTypeInfo.hashCode()
+  }
+
+  @VisibleForTesting
+  def getElemTypeInfo: TypeInformation[A] = elemTypeInfo
+}

--- a/src/main/scala/io/findify/flinkadt/api/typeinfo/ProductTypeInformation.scala
+++ b/src/main/scala/io/findify/flinkadt/api/typeinfo/ProductTypeInformation.scala
@@ -1,12 +1,9 @@
 package io.findify.flinkadt.api.typeinfo
 
-import magnolia1.{CaseClass, Param}
+import magnolia1.Param
 import org.apache.flink.api.common.ExecutionConfig
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.common.typeutils.TypeSerializer
-import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
-
-import scala.reflect._
 
 class ProductTypeInformation[T <: Product](c: Class[T], params: Seq[Param[TypeInformation, T]], ser: TypeSerializer[T])
     extends CaseClassTypeInfo[T](

--- a/src/test/scala/io/findify/flinkadt/ExampleTest.scala
+++ b/src/test/scala/io/findify/flinkadt/ExampleTest.scala
@@ -5,11 +5,13 @@ import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.common.restartstrategy.RestartStrategies
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
 
 class ExampleTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   lazy val cluster = new MiniClusterWithClientResource(
@@ -41,14 +43,13 @@ class ExampleTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
     import io.findify.flinkadt.api._
 
     implicit val eventTypeInfo: TypeInformation[Event] = deriveTypeInformation[Event]
-    val result = env.fromCollection(List[Event](Click("1"), Purchase(1.0))).executeAndCollect(10)
+    val result = env.fromCollection(List(Click("1"), Purchase(1.0)).asJava, eventTypeInfo).executeAndCollect(10)
     result.size shouldBe 2
   }
 }
 
 object ExampleTest {
-  sealed trait Event
-  case class Click(id: String)       extends Event
-  case class Purchase(price: Double) extends Event
-
+  sealed trait Event extends Product with Serializable
+  final case class Click(id: String) extends Event
+  final case class Purchase(price: Double) extends Event
 }

--- a/src/test/scala/io/findify/flinkadt/ExampleTest.scala
+++ b/src/test/scala/io/findify/flinkadt/ExampleTest.scala
@@ -1,19 +1,20 @@
 package io.findify.flinkadt
 
-import io.findify.flinkadt.ExampleTest.{Click, Event, Purchase}
+import io.findify.flinkadt.api._
 import org.apache.flink.api.common.RuntimeExecutionMode
 import org.apache.flink.api.common.restartstrategy.RestartStrategies
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
+import org.apache.flink.streaming.api.datastream.DataStreamSource
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.JavaConverters._
-
 class ExampleTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+  import ExampleTest._
+
   lazy val cluster = new MiniClusterWithClientResource(
     new MiniClusterResourceConfiguration.Builder().setNumberSlotsPerTaskManager(1).setNumberTaskManagers(1).build()
   )
@@ -40,16 +41,28 @@ class ExampleTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   }
 
   it should "run example code" in {
-    import io.findify.flinkadt.api._
+    val result = env
+      .fromScalaCollection(List(Event.Click("1"), Event.Purchase(1.0)))
+      .executeAndCollect(10)
 
-    implicit val eventTypeInfo: TypeInformation[Event] = deriveTypeInformation[Event]
-    val result = env.fromCollection(List(Click("1"), Purchase(1.0)).asJava, eventTypeInfo).executeAndCollect(10)
     result.size shouldBe 2
   }
 }
 
 object ExampleTest {
   sealed trait Event extends Product with Serializable
-  final case class Click(id: String) extends Event
-  final case class Purchase(price: Double) extends Event
+
+  object Event {
+    final case class Click(id: String) extends Event
+    final case class Purchase(price: Double) extends Event
+
+    implicit val eventTypeInfo: TypeInformation[Event] = deriveTypeInformation[Event]
+  }
+
+  implicit final class EnvOps(private val env: StreamExecutionEnvironment) extends AnyVal {
+    import scala.collection.JavaConverters._
+
+    def fromScalaCollection[A](data: Seq[A])(implicit typeInformation: TypeInformation[A]): DataStreamSource[A] =
+      env.fromCollection(data.asJava, typeInformation)
+  }
 }

--- a/src/test/scala/io/findify/flinkadt/SerializerTest.scala
+++ b/src/test/scala/io/findify/flinkadt/SerializerTest.scala
@@ -4,7 +4,6 @@ import cats.data.NonEmptyList
 import io.findify.flinkadt.SerializerTest.DeeplyNested.ModeNested.SuperNested.{Egg, Food}
 import io.findify.flinkadt.SerializerTest.NestedRoot.NestedMiddle.NestedBottom
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream}
 import io.findify.flinkadt.SerializerTest.{
   ADT,
   ADT2,
@@ -18,11 +17,10 @@ import io.findify.flinkadt.SerializerTest.{
   Generic,
   ListADT,
   Nested,
-  NestedParent,
-  Node,
   P2,
   Param,
   Simple,
+  SimpleEither,
   SimpleJava,
   SimpleList,
   SimpleOption,
@@ -31,14 +29,9 @@ import io.findify.flinkadt.SerializerTest.{
   WrappedADT
 }
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.api.common.typeutils.TypeSerializer
-import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
-import org.apache.flink.api.scala.typeutils.ScalaCaseClassSerializer
-import org.apache.flink.core.memory.{DataInputViewStreamWrapper, DataOutputViewStreamWrapper}
 import org.scalatest.Inspectors
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import io.findify.flinkadt.api._
 
 class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with TestUtils {
   import io.findify.flinkadt.api._
@@ -151,6 +144,12 @@ class SerializerTest extends AnyFlatSpec with Matchers with Inspectors with Test
     roundtrip(ser, SimpleOption(Some("foo")))
   }
 
+  it should "serialize Either" in {
+    val ser = implicitly[TypeInformation[SimpleEither]].createSerializer(null)
+    all(ser, SimpleEither(Left("foo")))
+    roundtrip(ser, SimpleEither(Right(42)))
+  }
+
   it should "serialize nested list of ADT" in {
     val ser = implicitly[TypeInformation[ListADT]].createSerializer(null)
     all(ser, ListADT(Nil))
@@ -226,6 +225,8 @@ object SerializerTest {
   case class Node(left: Option[Node], right: Option[Node])
 
   case class SimpleOption(a: Option[String])
+
+  case class SimpleEither(a: Either[String, Int])
 
   case class Generic[T](a: T, b: ADT)
 

--- a/src/test/scala/io/findify/flinkadt/TestUtils.scala
+++ b/src/test/scala/io/findify/flinkadt/TestUtils.scala
@@ -1,16 +1,16 @@
 package io.findify.flinkadt
 
+import io.findify.flinkadt.api.serializer.ScalaCaseClassSerializer
 import org.apache.flink.api.common.typeutils.TypeSerializer
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
-import org.apache.flink.api.scala.typeutils.ScalaCaseClassSerializer
 import org.apache.flink.core.memory.{DataInputViewStreamWrapper, DataOutputViewStreamWrapper}
-import org.scalatest.{Inspectors, Suite}
+import org.scalatest.{Assertion, Inspectors}
 import org.scalatest.matchers.should.Matchers
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectOutputStream}
 
 trait TestUtils extends Matchers with Inspectors {
-  def roundtrip[T](ser: TypeSerializer[T], in: T) = {
+  def roundtrip[T](ser: TypeSerializer[T], in: T): Assertion = {
     val out = new ByteArrayOutputStream()
     ser.serialize(in, new DataOutputViewStreamWrapper(out))
     val copy = ser.deserialize(new DataInputViewStreamWrapper(new ByteArrayInputStream(out.toByteArray)))
@@ -28,12 +28,12 @@ trait TestUtils extends Matchers with Inspectors {
       case _ => // ok
     }
 
-  def serializable[T](ser: TypeSerializer[T]) = {
+  def serializable[T](ser: TypeSerializer[T]): Unit = {
     val stream = new ObjectOutputStream(new ByteArrayOutputStream())
     stream.writeObject(ser)
   }
 
-  def all[T](ser: TypeSerializer[T], in: T) = {
+  def all[T](ser: TypeSerializer[T], in: T): Unit = {
     roundtrip(ser, in)
     noKryo(ser)
     serializable(ser)


### PR DESCRIPTION
In interest of eventually supporting Scala 2.13 / 3 in Flink 1.15, switch to using only Flink Java libraries. All transitive Scala dependencies from Flink are now gone.

- Port over common Scala classes, such as serializers / type info for Option, Either, etc..
- sbt & magnolia to latest.
- Switch to Flink 1.15 snapshot.
  * Required since `flink-test-utils` is compiled with Scala up until 1.15.